### PR TITLE
Replace toast usage with alert, remove toast package

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
-import Toast from 'react-native-toast-message';
 import AppProvider from './providers/AppProvider';
 import AppNavigator from './navigators/AppNavigator';
 
@@ -12,7 +11,6 @@ function App(): React.JSX.Element {
           <AppNavigator />
         </AppProvider>
       </GestureHandlerRootView>
-      <Toast />
     </>
   );
 }

--- a/example/contexts/JellyfishExampleContext.tsx
+++ b/example/contexts/JellyfishExampleContext.tsx
@@ -17,11 +17,9 @@ import {
   AudioOutputDeviceType,
   AudioSessionMode,
 } from '@jellyfish-dev/react-native-client-sdk';
-
-import Toast from 'react-native-toast-message';
-
 import {Platform} from 'expo-modules-core';
 import * as Device from 'expo-device';
+import {Alert} from 'react-native';
 
 type VideoRoomState = 'BeforeMeeting' | 'InMeeting' | 'AfterMeeting';
 
@@ -121,11 +119,10 @@ const JellyfishExampleContextProvider = (props: any) => {
 
   const toggleCamera = useCallback(async () => {
     if (isIosEmulator) {
-      Toast.show({
-        type: 'info',
-        text1: 'Camera is not supported on the iOS emulator',
-        text2: 'Please run the app on a real device to use the camera',
-      });
+      Alert.alert(
+        'Camera not supported on iOS simulator',
+        'Please run the app on a real device to use the camera',
+      );
 
       return;
     }

--- a/example/package.json
+++ b/example/package.json
@@ -26,8 +26,7 @@
     "react-native-gesture-handler": "~2.16.0",
     "react-native-reanimated": "^3.5.4",
     "react-native-safe-area-context": "4.8.2",
-    "react-native-screens": "^3.27.0",
-    "react-native-toast-message": "^2.2.0"
+    "react-native-screens": "^3.27.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -7695,11 +7695,6 @@ react-native-screens@^3.27.0:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
-react-native-toast-message@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-2.2.0.tgz#c53a4746b15616858a7d61c4386b92cbe9fbf911"
-  integrity sha512-AFti8VzUk6JvyGAlLm9/BknTNDXrrhqnUk7ak/pM7uCTxDPveAu2ekszU0on6vnUPFnG04H/QfYE2IlETqeaWw==
-
 react-native@0.73.4:
   version "0.73.4"
   resolved "https://registry.npmjs.org/react-native/-/react-native-0.73.4.tgz"


### PR DESCRIPTION
## Description
This PR replaces only usage of `react-native-toast-message` with `react-native` `Alert`.

## Motivation and Context
This PR decreases library amount as example app should be as compact as possible without unnecessary libraries.

## How has this been tested?
Tested on iOS 17.4 (iPhone 15 Pro Max simulator) only, as this change is applicable to iOS exclusively.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
![simulator_screenshot_018A2B90-BFD0-40D4-8B66-03F588729B40](https://github.com/jellyfish-dev/react-native-client-sdk/assets/41289688/0e5e3154-da31-4520-8e80-c708164a95d7)

