### PR TITLE
[EX-448] Add foreground service for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,77 @@ toggleScreencast({screencastMetadata: { displayName: "Annie's desktop" }});
 
 Use track metadata to differentiate between video and screencast tracks.
 
+### Android foreground service
+
+In order for the call to continue running when app is in background, you need to
+set up and start a foreground service. You can use a 3rd party library for this,
+for example [notifee](https://notifee.app/).
+
+In `AndroidManifest.xml` specify necessary permissions:
+
+```xml
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+```
+
+And add foreground service:
+
+```xml
+<application
+...
+>
+  ...
+  <service
+    android:name="app.notifee.core.ForegroundService"
+    android:foregroundServiceType="mediaProjection|camera|microphone" />
+</application>
+```
+
+Then to start the foreground service:
+
+```ts
+import notifee, { AndroidImportance } from '@notifee/react-native';
+
+const startForegroundService = async () => {
+  if (Platform.OS != 'android') return;
+  const channelId = await notifee.createChannel({
+    id: 'video_call',
+    name: 'Video call',
+    lights: false,
+    vibration: false,
+    importance: AndroidImportance.DEFAULT,
+  });
+
+  await notifee.displayNotification({
+    title: 'Your video call is ongoing',
+    body: 'Tap to return to the call.',
+    android: {
+      channelId,
+      asForegroundService: true,
+      ongoing: true,
+      pressAction: {
+        id: 'default',
+      },
+    },
+  });
+};
+```
+
+Don't forget to also stop the service when the call has ended:
+
+```ts
+notifee.stopForegroundService();
+```
+
+Also add this code in your `index.js` to register the service:
+
+```js
+notifee.registerForegroundService((notification) => {
+  return new Promise(() => {});
+});
+```
+
 ### Developing
 
 Run `./scripts/init.sh` in the main directory to install swift-format and set up

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Then to start the foreground service:
 import notifee, { AndroidImportance } from '@notifee/react-native';
 
 const startForegroundService = async () => {
-  if (Platform.OS != 'android') return;
+  if (Platform.OS === 'android') return;
   const channelId = await notifee.createChannel({
     id: 'video_call',
     name: 'Video call',

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,9 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 
@@ -27,5 +28,8 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <service
+          android:name="app.notifee.core.ForegroundService"
+          android:foregroundServiceType="mediaProjection|camera|microphone" />
     </application>
 </manifest>

--- a/example/contexts/FishjamExampleContext.tsx
+++ b/example/contexts/FishjamExampleContext.tsx
@@ -15,14 +15,14 @@ import {
   AudioOutputDeviceType,
   AudioSessionMode,
 } from '@fishjam-dev/react-native-client';
-import * as Device from 'expo-device';
-import { Platform } from 'expo-modules-core';
-import React, { useCallback, useEffect, useState } from 'react';
-import Toast from 'react-native-toast-message';
 import notifee, {
   AndroidImportance,
   AndroidColor,
 } from '@notifee/react-native';
+import * as Device from 'expo-device';
+import { Platform } from 'expo-modules-core';
+import React, { useCallback, useEffect, useState } from 'react';
+import Toast from 'react-native-toast-message';
 
 type VideoRoomState = 'BeforeMeeting' | 'InMeeting' | 'AfterMeeting';
 
@@ -61,29 +61,8 @@ const FishjamExampleContext = React.createContext<
 
 const isIosEmulator = Platform.OS === 'ios' && !Device.isDevice;
 
-const FishjamExampleContextProvider = (props: any) => {
-  const { join } = useFishjamClient();
-  const [isCameraOn, setIsCameraOn] = useState(!isIosEmulator);
-  const [isMicrophoneOn, setIsMicrophoneOn] = useState(true);
-  const [currentCamera, setCurrentCamera] = useState<CaptureDevice | null>(
-    null,
-  );
-  const {
-    toggleCamera: membraneToggleCamera,
-    startCamera,
-    flipCamera,
-    getCaptureDevices,
-    simulcastConfig: localCameraSimulcastConfig,
-    toggleVideoTrackEncoding: toggleLocalCameraTrackEncoding,
-  } = useCamera();
-  const { toggleMicrophone: membraneToggleMicrophone, startMicrophone } =
-    useMicrophone();
-  const audioSettings = useAudioSettings();
-  const [videoRoomState, setVideoRoomState] =
-    useState<VideoRoomState>('BeforeMeeting');
-
-  const startForegroundService = async () => {
-    if (Platform.OS != 'android') return;
+const startForegroundService = async () => {
+  if (Platform.OS === 'android') {
     const channelId = await notifee.createChannel({
       id: 'video_call',
       name: 'Video call',
@@ -106,7 +85,29 @@ const FishjamExampleContextProvider = (props: any) => {
         },
       },
     });
-  };
+  }
+};
+
+const FishjamExampleContextProvider = (props: any) => {
+  const { join } = useFishjamClient();
+  const [isCameraOn, setIsCameraOn] = useState(!isIosEmulator);
+  const [isMicrophoneOn, setIsMicrophoneOn] = useState(true);
+  const [currentCamera, setCurrentCamera] = useState<CaptureDevice | null>(
+    null,
+  );
+  const {
+    toggleCamera: membraneToggleCamera,
+    startCamera,
+    flipCamera,
+    getCaptureDevices,
+    simulcastConfig: localCameraSimulcastConfig,
+    toggleVideoTrackEncoding: toggleLocalCameraTrackEncoding,
+  } = useCamera();
+  const { toggleMicrophone: membraneToggleMicrophone, startMicrophone } =
+    useMicrophone();
+  const audioSettings = useAudioSettings();
+  const [videoRoomState, setVideoRoomState] =
+    useState<VideoRoomState>('BeforeMeeting');
 
   const joinRoom = useCallback(async () => {
     await startForegroundService();

--- a/example/contexts/FishjamExampleContext.tsx
+++ b/example/contexts/FishjamExampleContext.tsx
@@ -19,6 +19,10 @@ import * as Device from 'expo-device';
 import { Platform } from 'expo-modules-core';
 import React, { useCallback, useEffect, useState } from 'react';
 import Toast from 'react-native-toast-message';
+import notifee, {
+  AndroidImportance,
+  AndroidColor,
+} from '@notifee/react-native';
 
 type VideoRoomState = 'BeforeMeeting' | 'InMeeting' | 'AfterMeeting';
 
@@ -78,7 +82,34 @@ const FishjamExampleContextProvider = (props: any) => {
   const [videoRoomState, setVideoRoomState] =
     useState<VideoRoomState>('BeforeMeeting');
 
+  const startForegroundService = async () => {
+    if (Platform.OS != 'android') return;
+    const channelId = await notifee.createChannel({
+      id: 'video_call',
+      name: 'Video call',
+      lights: false,
+      vibration: false,
+      importance: AndroidImportance.DEFAULT,
+    });
+
+    await notifee.displayNotification({
+      title: 'Your video call is ongoing',
+      body: 'Tap to return to the call.',
+      android: {
+        channelId,
+        asForegroundService: true,
+        ongoing: true,
+        color: AndroidColor.BLUE,
+        colorized: true,
+        pressAction: {
+          id: 'default',
+        },
+      },
+    });
+  };
+
   const joinRoom = useCallback(async () => {
+    await startForegroundService();
     await startCamera({
       simulcastConfig: {
         enabled: true,

--- a/example/index.js
+++ b/example/index.js
@@ -6,7 +6,12 @@ import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';
 import { LogBox } from 'react-native';
+import notifee from '@notifee/react-native';
 
 LogBox.ignoreLogs(['new NativeEventEmitter']);
+
+notifee.registerForegroundService((notification) => {
+  return new Promise(() => {});
+});
 
 AppRegistry.registerComponent(appName, () => App);

--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,7 @@
     "@expo-google-fonts/noto-sans": "^0.2.3",
     "@fishjam-dev/react-native-client": "file:..",
     "@gorhom/bottom-sheet": "^4",
+    "@notifee/react-native": "^7.8.2",
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",

--- a/example/screens/RoomScreen.tsx
+++ b/example/screens/RoomScreen.tsx
@@ -5,6 +5,7 @@ import {
   ScreencastQuality,
 } from '@fishjam-dev/react-native-client';
 import BottomSheet from '@gorhom/bottom-sheet';
+import notifee from '@notifee/react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
@@ -14,7 +15,6 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import notifee from '@notifee/react-native';
 
 import { InCallButton, VideosGrid } from '../components';
 import { NoCameraView } from '../components/NoCameraView';

--- a/example/screens/RoomScreen.tsx
+++ b/example/screens/RoomScreen.tsx
@@ -14,6 +14,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
+import notifee from '@notifee/react-native';
 
 import { InCallButton, VideosGrid } from '../components';
 import { NoCameraView } from '../components/NoCameraView';
@@ -88,6 +89,12 @@ const RoomScreen = ({ navigation }: Props) => {
       bottomSheetRef.current?.expand();
     }
   }, [audioSettings]);
+
+  useEffect(() => {
+    return () => {
+      notifee.stopForegroundService();
+    };
+  }, []);
 
   return (
     <SafeAreaView style={styles.container}>

--- a/example/webdriverio-test/test/specs/test.e2e.ts
+++ b/example/webdriverio-test/test/specs/test.e2e.ts
@@ -1,3 +1,11 @@
+import {
+  ConfigurationParameters,
+  Configuration,
+  RoomApiFp,
+  AddPeerRequest,
+  PeerDetailsResponseData,
+  Room,
+} from '@fishjam-dev/js-server-sdk';
 import { driver } from '@wdio/globals';
 import * as assert from 'assert';
 import type { Suite } from 'mocha';
@@ -8,16 +16,6 @@ import {
   previewScreenLabels,
   soundOutputDevicesLabels,
 } from '../../../types/ComponentLabels';
-
-import {
-  ConfigurationParameters,
-  Configuration,
-  RoomApiFp,
-  AddPeerRequest,
-  PeerDetailsResponseData,
-  Room,
-} from '@fishjam-dev/js-server-sdk';
-
 import {
   getElement,
   getWebsocketUrl,

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1611,6 +1611,7 @@
 "@fishjam-dev/react-native-client@file:..":
   version "0.3.0"
   dependencies:
+    "@notifee/react-native" "^7.8.2"
     phoenix "^1.7.6"
     promise-fs "^2.1.1"
     protobufjs "^7.2.4"
@@ -1977,6 +1978,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@notifee/react-native@^7.8.2":
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/@notifee/react-native/-/react-native-7.8.2.tgz#72d3199ae830b4128ddaef3c1c2f11604759c9c4"
+  integrity sha512-VG4IkWJIlOKqXwa3aExC3WFCVCGCC9BA55Ivg0SMRfEs+ruvYy/zlLANcrVGiPtgkUEryXDhA8SXx9+JcO8oLA==
 
 "@npmcli/fs@^1.0.0":
   version "1.1.1"


### PR DESCRIPTION
This PR:
- adds a foreground service to the example app on Android
- adds documentation in README on how to add a foreground service

Foreground service is needed in order to keep the call ongoing when the app is in background.